### PR TITLE
Articles form

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -1,4 +1,5 @@
 class ArticlesController < ApplicationController
+  skip_before_action :verify_authenticity_token
   before_action :set_article, except: %i[index new create]
 
   # GET /articles or /articles.json
@@ -25,10 +26,8 @@ class ArticlesController < ApplicationController
 
     respond_to do |format|
       if @article.save
-        format.html { redirect_to article_url(@article), notice: "Article was successfully created." }
-        format.json { render :show, status: :created, location: @article }
+        format.json { render json: @article, status: :created }
       else
-        format.html { render :new, status: :unprocessable_entity }
         format.json { render json: @article.errors, status: :unprocessable_entity }
       end
     end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,5 +1,5 @@
-import React from 'react';
 import axios from 'axios';
+import React from 'react';
 import ReactDOM from 'react-dom';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import FullArticle from './pages/fullArticle.js';

--- a/app/javascript/components/ArticleForm.js
+++ b/app/javascript/components/ArticleForm.js
@@ -1,0 +1,100 @@
+import axios from 'axios';
+import React, { useState } from 'react';
+import { Form, FormGroup, TextInput, Modal, ModalVariant, Button } from '@patternfly/react-core';
+import PropTypes from 'prop-types';
+
+const ArticleForm = ({ isOpen, handleModalToggle }) => {
+  const [data, setData] = useState({
+    title: '',
+    body: '',
+    creator: ''
+  });
+
+  const handleChange = (value, key) => {
+    setData({
+      ...data,
+      [key]: value
+    });
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    const userData = {
+      title: data.title,
+      body: data.body,
+      creator: data.creator
+    };
+    axios
+      .post('/articles', userData)
+      .then((response) => {
+        console.log('response.data: ' + JSON.stringify(response.data));
+        alert('Article created successfully.');
+      })
+      .catch((error) => {
+        if (error.response) {
+          console.log('error: ' + error);
+          console.log('server responded');
+        } else if (error.request) {
+          console.log('network error');
+        } else {
+          console.log(error);
+        }
+      });
+  };
+
+  return (
+    <div>
+      <Modal
+        variant={ModalVariant.small}
+        title="Create article"
+        description="Enter the details below to post an article."
+        isOpen={isOpen}
+        onClose={handleModalToggle}
+        actions={[
+          <Button key="create" variant="primary" form="modal-with-form-form" onClick={handleSubmit}>
+            Confirm
+          </Button>,
+          <Button key="cancel" variant="link" onClick={handleModalToggle}>
+            Cancel
+          </Button>
+        ]}>
+        <Form id="modal-with-form-form">
+          <FormGroup label="Title" isRequired fieldId="modal-with-form-form-title">
+            <TextInput
+              isRequired
+              id="modal-with-form-form-title"
+              type="text"
+              value={data.title}
+              onChange={(value) => handleChange(value, 'title')}
+            />
+          </FormGroup>
+          <FormGroup label="Body" isRequired>
+            <TextInput
+              isRequired
+              id="modal-with-form-form-body"
+              type="text"
+              value={data.body}
+              onChange={(value) => handleChange(value, 'body')}
+            />
+          </FormGroup>
+          <FormGroup label="Creator" isRequired>
+            <TextInput
+              isRequired
+              id="modal-with-form-form-creator"
+              type="text"
+              value={data.creator}
+              onChange={(value) => handleChange(value, 'creator')}
+            />
+          </FormGroup>
+        </Form>
+      </Modal>
+    </div>
+  );
+};
+
+ArticleForm.propTypes = {
+  isOpen: PropTypes.string.isRequired,
+  handleModalToggle: PropTypes.string.isRequired
+};
+
+export default ArticleForm;

--- a/app/javascript/pages/home.js
+++ b/app/javascript/pages/home.js
@@ -1,11 +1,14 @@
-import React from 'react';
-import { Gallery, GalleryItem, Text } from '@patternfly/react-core';
+import axios from 'axios';
+import React, { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import ArticleCard from '../components/articleCard.js';
+import '@patternfly/react-core/dist/styles/base.css';
+import PlusCircleIcon from '@patternfly/react-icons/dist/esm/icons/plus-circle-icon';
 import previewImage from '../../assets/images/img1.png';
 import colors from '../utils/colors.js';
-import { useNavigate } from 'react-router-dom';
-import { useState, useEffect } from 'react';
-import axios from 'axios';
+import { Gallery, GalleryItem, Text, Button } from '@patternfly/react-core';
+import ArticleForm from '../components/ArticleForm.js';
+
 const styles = {
   headerText: {
     fontWeight: 'bolder',
@@ -15,9 +18,16 @@ const styles = {
     fontSize: '50px'
   }
 };
+
 const Home = () => {
   const navigate = useNavigate();
   const [articles, setArticles] = useState([]);
+  const [isModalOpen, setModalOpen] = useState(false);
+
+  const handleModalToggle = () => {
+    setModalOpen((prevValue) => !prevValue);
+  };
+
   useEffect(() => {
     axios
       .get('/articles')
@@ -29,7 +39,14 @@ const Home = () => {
 
   return (
     <>
-      <Text style={styles.headerText}>Articles for you!!!</Text>
+      <Text style={styles.headerText}>Satellite Newsletter</Text>
+      <React.Fragment>
+        <Button variant="link" icon={<PlusCircleIcon />} onClick={handleModalToggle}>
+          Create Article
+        </Button>{' '}
+        <ArticleForm isOpen={isModalOpen} handleModalToggle={handleModalToggle} />
+      </React.Fragment>
+
       <Gallery
         hasGutter
         style={{ marginInline: '3%' }}

--- a/test/controllers/articles_controller_test.rb
+++ b/test/controllers/articles_controller_test.rb
@@ -21,10 +21,10 @@ class ArticlesControllerTest < ActionDispatch::IntegrationTest
     assert_difference("Article.count") do
       post articles_url,
            params: { article: { body: @article.body, title: @article.title,
-                                creator: @article.creator } }
+                                creator: @article.creator }, format: :json }
     end
 
-    assert_redirected_to article_url(Article.last)
+    assert_response :success
   end
 
   test "should show article" do


### PR DESCRIPTION
Add `ArticleForm` component to create an article, based on:  a7254c3e528c096dc3fb03c46e9d578523dd2dbd

This PR contains the following:
- added article form modal in separate component `ArticleForm.js`
- used patternfly to add form fields and modal.
- added axios `.get` and `.post` request, but you can refer `axios .get` request from @girijaasoni PR https://github.com/girijaasoni/newsletterApplicaton/issues/29
- few changes in the UI
  - ~removed the image from the article, @girijaasoni let me know what do you think. I guess we can implement it later~
  - change the headline for `Articles for you` to `Satellite Newsletter`


Resolves #27 Add articles form to create articles
